### PR TITLE
Add back "auth=" in query_jobs_schedule

### DIFF
--- a/buildapi_client/buildapi_client.py
+++ b/buildapi_client/buildapi_client.py
@@ -209,7 +209,7 @@ def query_jobs_schedule(repo_name, revision, auth):
     """
     url = "%s/%s/rev/%s?format=json" % (SELF_SERVE, repo_name, revision)
     LOG.debug("About to fetch %s" % url)
-    req = requests.get(url, auth)
+    req = requests.get(url, auth=auth)
 
     # If the revision doesn't exist on buildapi, that means there are
     # no builapi jobs for this revision


### PR DESCRIPTION
This was removed in 32913a7. I don't see any reason that should be removed there. I suppose that was removed by mistake.

This change fixes mozilla/mozilla_ci_tools#420.
